### PR TITLE
Try to fix igraph installation

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -66,6 +66,7 @@ jobs:
           sudo -s eval "$sysreqs"
       - name: Install dependencies
         run: |
+          options("pkgType" = "binary") #see: https://github.com/r-lib/actions/issues/141#issuecomment-664390398
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}


### PR DESCRIPTION
by using latest binary (as currently latest on CRAN is "source" version, which requires a lot of system dependencies: https://github.com/igraph/rigraph/blob/0af0caf20391a3864f766ddba8b86e87c2558f78/.github/workflows/build-and-check.yml#L127)

Use fix provided by Jim Hester:
https://github.com/r-lib/actions/issues/141#issuecomment-664390398

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kwb-r/fakin.path.app/14)
<!-- Reviewable:end -->
