### PR TITLE
Set format.legend() to list(), not NULL

### DIFF
--- a/R/plot_treemaps.R
+++ b/R/plot_treemaps.R
@@ -86,6 +86,9 @@ plot_treemaps_from_path_data <- function(
   depth = 1, types = c("size", "files")
 )
 {
+  #kwb.utils::assignPackageObjects("fakin.path.app")
+  #kwb.utils::assignArgumentDefaults(fakin.path.app:::plot_treemaps_from_path_data)
+  
   if (! inherits(path_data, "pathlist") && ! check_path_data(path_data)) {
     return()
   }
@@ -109,6 +112,7 @@ plot_treemaps_from_path_data <- function(
 
   maps <- lapply(types, function(map_type) {
 
+    #map_type <- types[1L]
     map <- kwb.utils::catAndRun(
       sprintf("Creating treemap '%s'", map_type),
       kwb.utils::callWith(
@@ -255,7 +259,11 @@ args_treemap <- function(
     vSize = setting$column,
     vColor = anti_setting$column,
     title = setting$title,
-    title.legend = setting$legend
+    title.legend = setting$legend,
+    # The default value "NULL" of argument "format.legend" in treemap::treemap()
+    # leads to an error! It must be a list since this list is finally passed
+    # to do.call() (e.g. in treemap:::dens2col())
+    format.legend = list() 
   )
 }
 
@@ -406,7 +414,7 @@ plot_treemap <- function(
   #args <- list()
   args <- list(...)
 
-  if (length(args) == 0) {
+  if (length(args) == 0L) {
     args <- args_treemap()
   }
 

--- a/tests/testthat/test-function-args_treemap.R
+++ b/tests/testthat/test-function-args_treemap.R
@@ -1,8 +1,11 @@
 test_that("args_treemap() works", {
 
   testthat::expect_identical(
-    names(fakin.path.app:::args_treemap()),
-    c("index", "type", "border.col", "vSize", "vColor", "title", "title.legend")
+    names(fakin.path.app:::args_treemap()), 
+    c(
+      "index", "type", "border.col", "vSize", "vColor", "title", "title.legend", 
+      "format.legend"
+    )
   )
-
+  
 })

--- a/tests/testthat/test-function-plot_treemaps_from_path_data.R
+++ b/tests/testthat/test-function-plot_treemaps_from_path_data.R
@@ -10,5 +10,6 @@ test_that("plot_treemaps_from_path_data() works", {
     type = "file"
   )
 
-  expect_error(f(path_data, n_levels = 1))
+  f(path_data)
+  f(path_data, n_levels = 1L)
 })


### PR DESCRIPTION
Otherwise an error occurs in e.g.
treemap:::dens2col() when calling do.call("format", args) with args being NULL
instead of a list(). This should close #15.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kwb-r/fakin.path.app/16)
<!-- Reviewable:end -->
